### PR TITLE
Added keyboard shortcut for code selection

### DIFF
--- a/frontend/background.js
+++ b/frontend/background.js
@@ -40,3 +40,13 @@ chrome.runtime.onMessage.addListener((request, _, sendResponse) => {
     return true;
   }
 });
+//Default commmand = Alt+T , Mac  = Option+T
+chrome.commands.onCommand.addListener((command) => {
+  if (command === "enable-code-selection") {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      if (tabs.length > 0) {
+        chrome.tabs.sendMessage(tabs[0].id, { type: "ENABLE_PICKER" });
+      }
+    });
+  }
+});

--- a/frontend/background.js
+++ b/frontend/background.js
@@ -42,7 +42,7 @@ chrome.runtime.onMessage.addListener((request, _, sendResponse) => {
 });
 //Default commmand = Alt+T , Mac  = Option+T
 chrome.commands.onCommand.addListener((command) => {
-  if (command === "enable-code-selection") {
+  if (command === "translate") {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       if (tabs.length > 0) {
         chrome.tabs.sendMessage(tabs[0].id, { type: "ENABLE_PICKER" });

--- a/frontend/manifest.json
+++ b/frontend/manifest.json
@@ -38,5 +38,13 @@
       "resources": ["packages/prism.css"],
       "matches": ["<all_urls>"]
     }
-  ]
+  ],
+  "commands": {
+    "enable-code-selection": {
+      "suggested_key": {
+        "default": "Alt+T" 
+      },
+      "description": "Activate code selection mode."
+    }
+  }
 }

--- a/frontend/manifest.json
+++ b/frontend/manifest.json
@@ -40,11 +40,12 @@
     }
   ],
   "commands": {
-    "enable-code-selection": {
+    "translate": {
       "suggested_key": {
-        "default": "Alt+T" 
+        "default": "Alt+Shift+A",
+        "mac": "Alt+Shift+A"
       },
-      "description": "Activate code selection mode."
+      "description": "Translate selected text"
     }
   }
 }


### PR DESCRIPTION
### Summary
I've added a keyboard shortcut (Alt+T / Option+T) to activate the code selection mode in the extension.

### Details
- Defined a new command `enable-code-selection` in `manifest.json`
- Assigned the shortcut key for both default and macOS platforms (`Alt` maps to `Option` on macOS)
- Added a command listener in the background script to trigger the picker

Please review the changes and let me know if there's anything I can improve or refine. 🙂
closes #14 
